### PR TITLE
Correct minor typo in usage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 Lookup by email:
 	* `$person = FullContact::lookupByEmail( 'shawn@mantelope.io' );`
 
-Lookup by person:
+Lookup by phone:
 	* `$person = FullContact::lookupByPhone( '123-456-7890' );`
 
 Lookup by Twitter: 


### PR DESCRIPTION
Said lookup by person, should have said lookup by phone.
