### PR TITLE
Ignore cache if retrieving stats

### DIFF
--- a/src/FullContact.php
+++ b/src/FullContact.php
@@ -96,7 +96,6 @@ class FullContact
 			$cached_json = $this->_getFromCache($fullUrl);
 		}
 
-		// $cached_json = $this->_getFromCache($fullUrl);
 		if ( $cached_json !== false )
 		{
 			$this->response_json = $cached_json;

--- a/src/FullContact.php
+++ b/src/FullContact.php
@@ -84,9 +84,19 @@ class FullContact
 		else
 		{
 			$fullUrl = $this->_baseUri . $this->_version . $resource_uri .'?' . http_build_query($params);
+			
 		}
 		
-		$cached_json = $this->_getFromCache($fullUrl);
+		if ($resource_uri === "/stats.json")
+		{
+			$cached_json = false;
+		}
+		else
+		{
+			$cached_json = $this->_getFromCache($fullUrl);
+		}
+
+		// $cached_json = $this->_getFromCache($fullUrl);
 		if ( $cached_json !== false )
 		{
 			$this->response_json = $cached_json;


### PR DESCRIPTION
If you are retrieving stats, then it ignores the cache so that the stats are fresh - since this process doesn't count against any account totals